### PR TITLE
two small fixes for Unity 2018 compatibility

### DIFF
--- a/Assets/RetroTVEffects/Examples/Scripts/ToggleCRTEffects.cs
+++ b/Assets/RetroTVEffects/Examples/Scripts/ToggleCRTEffects.cs
@@ -1,8 +1,6 @@
 ﻿using UnityEngine;
 using System.Collections;
 
-using UnityStandardAssets.ImageEffects;
-
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 

--- a/Assets/RetroTVEffects/Resources/Shaders/ImageEffects/RetroTV.cginc
+++ b/Assets/RetroTVEffects/Resources/Shaders/ImageEffects/RetroTV.cginc
@@ -37,6 +37,7 @@
 // PARAMETERS
 // ====================
 sampler2D _MainTex;
+float4 _MainTex_ST;
 
 sampler2D _PixelMask;
 float4 _PixelMaskScale;


### PR DESCRIPTION
tested on Unity 2018.3.11f1, pretty simple and straightforward minor fixes I think

but chances are, if you knew how to download the latest commits (instead of the older .unitypackage in the release) then you were probably savvy enough to fix it yourself